### PR TITLE
fix: fix the bug of reactAgent example

### DIFF
--- a/spring-ai-alibaba-graph-example/react/src/main/java/com/alibaba/cloud/ai/graph/react/ReactAutoconfiguration.java
+++ b/spring-ai-alibaba-graph-example/react/src/main/java/com/alibaba/cloud/ai/graph/react/ReactAutoconfiguration.java
@@ -61,14 +61,14 @@ public class ReactAutoconfiguration {
 	public CompiledGraph reactAgentGraph(@Qualifier("normalReactAgent") ReactAgent reactAgent)
 			throws GraphStateException {
 
-		GraphRepresentation graphRepresentation = reactAgent.getStateGraph()
-			.getGraph(GraphRepresentation.Type.PLANTUML);
+		CompiledGraph compiledGraph = reactAgent.getAndCompileGraph();
 
+		GraphRepresentation graphRepresentation = compiledGraph.getGraph(GraphRepresentation.Type.PLANTUML);
 		System.out.println("\n\n");
 		System.out.println(graphRepresentation.content());
 		System.out.println("\n\n");
 
-		return reactAgent.getAndCompileGraph();
+		return compiledGraph;
 	}
 
 	@Bean


### PR DESCRIPTION
## What does this PR do?
fix the bug of reactAgent example

## Reason 
The original reactAgent.getStateGraph() would return a null pointer before compilation.

